### PR TITLE
docs(plan): implementation roadmap (V1/V2) and task list

### DIFF
--- a/plan/README.md
+++ b/plan/README.md
@@ -1,0 +1,21 @@
+# Plan README
+
+This directory provides two roadmap options:
+
+- `roadmap_v1.md`: conservative sequential plan. Used for `tasks.json`.
+- `roadmap_v2.md`: aggressive batching allowing parallel work.
+
+`tasks.json` follows V1 to minimize risks and ensure clear audit trail.
+
+## Running tasks manually
+
+From repository root:
+
+```
+ruff check .
+ruff format .
+black --check .
+pytest -q
+```
+
+Run these commands after each change to verify linting, formatting, and tests.

--- a/plan/roadmap_v1.md
+++ b/plan/roadmap_v1.md
@@ -1,19 +1,154 @@
-# Roadmap v1
+# Implementation Roadmap V1 (Conservative)
 
 ## P0
-- **DR_P0_001 – Fix dependencies and add dev tools**
-  - changes: `requirements.txt`, `pyproject.toml`
-  - commands: `pip install -r requirements.txt`, `ruff check .`, `ruff format .`, `black --check .`
-  - DoD: dependencies install; lint/format pass
-  - risk: low
-- **DR_P0_002 – Enable pytest discovery**
-  - changes: `pyproject.toml`, `crypto_decline_index/tests/__init__.py`
-  - commands: `pytest -q`
-  - DoD: tests run without ModuleNotFoundError
-  - risk: low
+
+- **DR_0001** — review and implement recommendations
+  - changes: ['docs/compliance/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes']
+  - ref: [dr/analyses/DR_0001.yaml#L202-L216](dr/analyses/DR_0001.yaml#L202-L216)
+- **DR_0002** — review and implement recommendations
+  - changes: ['core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime']
+  - ref: [dr/analyses/DR_0002.yaml#L254-L273](dr/analyses/DR_0002.yaml#L254-L273)
+- **DR_0003** — review and implement recommendations
+  - changes: ['docs/compliance/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes']
+  - ref: [dr/analyses/DR_0003.yaml#L18-L32](dr/analyses/DR_0003.yaml#L18-L32)
+- **DR_0004** — review and implement recommendations
+  - changes: ['bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes']
+  - ref: [dr/analyses/DR_0004.yaml#L39-L54](dr/analyses/DR_0004.yaml#L39-L54)
+- **DR_0005** — review and implement recommendations
+  - changes: ['bot/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime']
+  - ref: [dr/analyses/DR_0005.yaml#L40-L60](dr/analyses/DR_0005.yaml#L40-L60)
+- **DR_0006** — review and implement recommendations
+  - changes: ['bot/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime']
+  - ref: [dr/analyses/DR_0006.yaml#L400-L420](dr/analyses/DR_0006.yaml#L400-L420)
+- **DR_0007** — review and implement recommendations
+  - changes: ['bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes']
+  - ref: [dr/analyses/DR_0007.yaml#L30-L45](dr/analyses/DR_0007.yaml#L30-L45)
+- **DR_0008** — review and implement recommendations
+  - changes: ['bot/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'vulnerability scan clean']
+  - risk: ['API rate limits', 'KYC limitations', 'data breaches', 'flaky tests', 'misconfigured auth', 'regulatory changes', 'third-party downtime']
+  - ref: [dr/analyses/DR_0008.yaml#L406-L429](dr/analyses/DR_0008.yaml#L406-L429)
 
 ## P1
-_No DR analyses found._
+
+- **DR_0009** — review and implement recommendations
+  - changes: ['tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['pytest -q passes']
+  - risk: ['flaky tests']
+  - ref: [dr/analyses/DR_0009.yaml#L10-L17](dr/analyses/DR_0009.yaml#L10-L17)
+- **DR_0010** — review and implement recommendations
+  - changes: ['static/', 'templates/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted']
+  - risk: ['general implementation risk']
+  - ref: [dr/analyses/DR_0010.yaml#L14-L22](dr/analyses/DR_0010.yaml#L14-L22)
+- **DR_0011** — review and implement recommendations
+  - changes: ['bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes']
+  - ref: [dr/analyses/DR_0011.yaml#L34-L49](dr/analyses/DR_0011.yaml#L34-L49)
+- **DR_0012** — review and implement recommendations
+  - changes: ['(none specified)']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['pytest -q passes']
+  - risk: ['general implementation risk']
+  - ref: [dr/analyses/DR_0012.yaml#L23-L29](dr/analyses/DR_0012.yaml#L23-L29)
+- **DR_0013** — review and implement recommendations
+  - changes: ['bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes']
+  - ref: [dr/analyses/DR_0013.yaml#L29-L44](dr/analyses/DR_0013.yaml#L29-L44)
+- **DR_0014** — review and implement recommendations
+  - changes: ['core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime']
+  - ref: [dr/analyses/DR_0014.yaml#L247-L266](dr/analyses/DR_0014.yaml#L247-L266)
+- **DR_0015** — review and implement recommendations
+  - changes: ['(none specified)']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['pytest -q passes']
+  - risk: ['general implementation risk']
+  - ref: [dr/analyses/DR_0015.yaml#L16-L22](dr/analyses/DR_0015.yaml#L16-L22)
+- **DR_0016** — review and implement recommendations
+  - changes: ['bot/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'pytest -q passes']
+  - risk: ['flaky tests']
+  - ref: [dr/analyses/DR_0016.yaml#L29-L40](dr/analyses/DR_0016.yaml#L29-L40)
 
 ## P2
-_No DR analyses found._
+
+- **DR_0017** — review and implement recommendations
+  - changes: ['(none specified)']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['pytest -q passes']
+  - risk: ['general implementation risk']
+  - ref: [dr/analyses/DR_0017.yaml#L19-L25](dr/analyses/DR_0017.yaml#L19-L25)
+- **DR_0018** — review and implement recommendations
+  - changes: ['docs/compliance/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['manual review by compliance officer', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes']
+  - ref: [dr/analyses/DR_0018.yaml#L23-L34](dr/analyses/DR_0018.yaml#L23-L34)
+- **DR_0019** — review and implement recommendations
+  - changes: ['docs/compliance/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes']
+  - ref: [dr/analyses/DR_0019.yaml#L29-L43](dr/analyses/DR_0019.yaml#L29-L43)
+- **DR_0020** — review and implement recommendations
+  - changes: ['core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime']
+  - ref: [dr/analyses/DR_0020.yaml#L67-L86](dr/analyses/DR_0020.yaml#L67-L86)
+- **DR_0021** — review and implement recommendations
+  - changes: ['(none specified)']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['pytest -q passes']
+  - risk: ['general implementation risk']
+  - ref: [dr/analyses/DR_0021.yaml#L10-L16](dr/analyses/DR_0021.yaml#L10-L16)
+- **DR_0022** — review and implement recommendations
+  - changes: ['static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'pytest -q passes']
+  - risk: ['flaky tests']
+  - ref: [dr/analyses/DR_0022.yaml#L24-L34](dr/analyses/DR_0022.yaml#L24-L34)
+- **DR_0023** — review and implement recommendations
+  - changes: ['core/', 'docs/compliance/', 'integrations/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['HTTP 200 from integration endpoints', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime']
+  - ref: [dr/analyses/DR_0023.yaml#L68-L84](dr/analyses/DR_0023.yaml#L68-L84)
+- **DR_0024** — review and implement recommendations
+  - changes: ['core/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['HTTP 200 from integration endpoints', 'UX review accepted', 'pytest -q passes', 'vulnerability scan clean']
+  - risk: ['API rate limits', 'data breaches', 'flaky tests', 'misconfigured auth', 'third-party downtime']
+  - ref: [dr/analyses/DR_0024.yaml#L56-L74](dr/analyses/DR_0024.yaml#L56-L74)

--- a/plan/roadmap_v2.md
+++ b/plan/roadmap_v2.md
@@ -1,0 +1,46 @@
+# Implementation Roadmap V2 (Aggressive)
+
+## P0
+
+- **Batch 1 (DR_0001, DR_0002, DR_0003, DR_0004)** — parallel implementation
+  - changes: ['docs/compliance/', 'static/', 'templates/', 'tests/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/', 'docs/compliance/', 'static/', 'templates/', 'tests/', 'bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'KYC limitations', 'flaky tests', 'regulatory changes', 'KYC limitations', 'flaky tests', 'regulatory changes']
+  - refs: [DR_0001](dr/analyses/DR_0001.yaml#L202-L216), [DR_0002](dr/analyses/DR_0002.yaml#L254-L273), [DR_0003](dr/analyses/DR_0003.yaml#L18-L32), [DR_0004](dr/analyses/DR_0004.yaml#L39-L54)
+- **Batch 2 (DR_0005, DR_0006, DR_0007, DR_0008)** — parallel implementation
+  - changes: ['bot/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/', 'bot/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/', 'bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/', 'bot/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'vulnerability scan clean']
+  - risk: ['API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'KYC limitations', 'flaky tests', 'regulatory changes', 'API rate limits', 'KYC limitations', 'data breaches', 'flaky tests', 'misconfigured auth', 'regulatory changes', 'third-party downtime']
+  - refs: [DR_0005](dr/analyses/DR_0005.yaml#L40-L60), [DR_0006](dr/analyses/DR_0006.yaml#L400-L420), [DR_0007](dr/analyses/DR_0007.yaml#L30-L45), [DR_0008](dr/analyses/DR_0008.yaml#L406-L429)
+
+## P1
+
+- **Batch 1 (DR_0009, DR_0010, DR_0011, DR_0012)** — parallel implementation
+  - changes: ['tests/', 'static/', 'templates/', 'bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['pytest -q passes', 'UX review accepted', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'pytest -q passes']
+  - risk: ['flaky tests', 'general implementation risk', 'KYC limitations', 'flaky tests', 'regulatory changes', 'general implementation risk']
+  - refs: [DR_0009](dr/analyses/DR_0009.yaml#L10-L17), [DR_0010](dr/analyses/DR_0010.yaml#L14-L22), [DR_0011](dr/analyses/DR_0011.yaml#L34-L49), [DR_0012](dr/analyses/DR_0012.yaml#L23-L29)
+- **Batch 2 (DR_0013, DR_0014, DR_0015, DR_0016)** — parallel implementation
+  - changes: ['bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/', 'bot/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'pytest -q passes', 'UX review accepted', 'pytest -q passes']
+  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'general implementation risk', 'flaky tests']
+  - refs: [DR_0013](dr/analyses/DR_0013.yaml#L29-L44), [DR_0014](dr/analyses/DR_0014.yaml#L247-L266), [DR_0015](dr/analyses/DR_0015.yaml#L16-L22), [DR_0016](dr/analyses/DR_0016.yaml#L29-L40)
+
+## P2
+
+- **Batch 1 (DR_0017, DR_0018, DR_0019, DR_0020)** — parallel implementation
+  - changes: ['docs/compliance/', 'tests/', 'docs/compliance/', 'static/', 'templates/', 'tests/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['pytest -q passes', 'manual review by compliance officer', 'pytest -q passes', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
+  - risk: ['general implementation risk', 'KYC limitations', 'flaky tests', 'regulatory changes', 'KYC limitations', 'flaky tests', 'regulatory changes', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime']
+  - refs: [DR_0017](dr/analyses/DR_0017.yaml#L19-L25), [DR_0018](dr/analyses/DR_0018.yaml#L23-L34), [DR_0019](dr/analyses/DR_0019.yaml#L29-L43), [DR_0020](dr/analyses/DR_0020.yaml#L67-L86)
+- **Batch 2 (DR_0021, DR_0022, DR_0023, DR_0024)** — parallel implementation
+  - changes: ['static/', 'templates/', 'tests/', 'core/', 'docs/compliance/', 'integrations/', 'tests/', 'core/', 'integrations/', 'static/', 'templates/', 'tests/']
+  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
+  - DoD: ['pytest -q passes', 'UX review accepted', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'pytest -q passes', 'vulnerability scan clean']
+  - risk: ['general implementation risk', 'flaky tests', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'API rate limits', 'data breaches', 'flaky tests', 'misconfigured auth', 'third-party downtime']
+  - refs: [DR_0021](dr/analyses/DR_0021.yaml#L10-L16), [DR_0022](dr/analyses/DR_0022.yaml#L24-L34), [DR_0023](dr/analyses/DR_0023.yaml#L68-L84), [DR_0024](dr/analyses/DR_0024.yaml#L56-L74)

--- a/plan/roadmap_v2.md
+++ b/plan/roadmap_v2.md
@@ -1,46 +1,79 @@
-# Implementation Roadmap V2 (Aggressive)
+# Roadmap V2 (Aggressive)
 
 ## P0
-
-- **Batch 1 (DR_0001, DR_0002, DR_0003, DR_0004)** — parallel implementation
-  - changes: ['docs/compliance/', 'static/', 'templates/', 'tests/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/', 'docs/compliance/', 'static/', 'templates/', 'tests/', 'bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/']
-  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
-  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
-  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'KYC limitations', 'flaky tests', 'regulatory changes', 'KYC limitations', 'flaky tests', 'regulatory changes']
-  - refs: [DR_0001](dr/analyses/DR_0001.yaml#L202-L216), [DR_0002](dr/analyses/DR_0002.yaml#L254-L273), [DR_0003](dr/analyses/DR_0003.yaml#L18-L32), [DR_0004](dr/analyses/DR_0004.yaml#L39-L54)
-- **Batch 2 (DR_0005, DR_0006, DR_0007, DR_0008)** — parallel implementation
-  - changes: ['bot/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/', 'bot/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/', 'bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/', 'bot/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
-  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
-  - DoD: ['HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'vulnerability scan clean']
-  - risk: ['API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'KYC limitations', 'flaky tests', 'regulatory changes', 'API rate limits', 'KYC limitations', 'data breaches', 'flaky tests', 'misconfigured auth', 'regulatory changes', 'third-party downtime']
-  - refs: [DR_0005](dr/analyses/DR_0005.yaml#L40-L60), [DR_0006](dr/analyses/DR_0006.yaml#L400-L420), [DR_0007](dr/analyses/DR_0007.yaml#L30-L45), [DR_0008](dr/analyses/DR_0008.yaml#L406-L429)
+- **Batch 1**: DR_0001, DR_0002
+  - changes: core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0001.yaml (L1587-L2396); dr/analyses/DR_0002.yaml (L2718-L2755)
+- **Batch 2**: DR_0003, DR_0004
+  - changes: bot/, docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - refs: dr/analyses/DR_0003.yaml (L3150-L3195); dr/analyses/DR_0004.yaml (L3324-L3369)
+- **Batch 3**: DR_0005, DR_0006
+  - changes: bot/, core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0005.yaml (L3411-L3454); dr/analyses/DR_0006.yaml (L4289-L7541)
+- **Batch 4**: DR_0007, DR_0008
+  - changes: bot/, core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes, vulnerability scan clean
+  - risk: API rate limits, KYC limitations, data breaches, flaky tests, misconfigured auth, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0007.yaml (L7765-L7811); dr/analyses/DR_0008.yaml (L7863-L8917)
 
 ## P1
-
-- **Batch 1 (DR_0009, DR_0010, DR_0011, DR_0012)** — parallel implementation
-  - changes: ['tests/', 'static/', 'templates/', 'bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/']
-  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
-  - DoD: ['pytest -q passes', 'UX review accepted', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'pytest -q passes']
-  - risk: ['flaky tests', 'general implementation risk', 'KYC limitations', 'flaky tests', 'regulatory changes', 'general implementation risk']
-  - refs: [DR_0009](dr/analyses/DR_0009.yaml#L10-L17), [DR_0010](dr/analyses/DR_0010.yaml#L14-L22), [DR_0011](dr/analyses/DR_0011.yaml#L34-L49), [DR_0012](dr/analyses/DR_0012.yaml#L23-L29)
-- **Batch 2 (DR_0013, DR_0014, DR_0015, DR_0016)** — parallel implementation
-  - changes: ['bot/', 'docs/compliance/', 'static/', 'templates/', 'tests/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/', 'bot/', 'static/', 'templates/', 'tests/']
-  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
-  - DoD: ['UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'pytest -q passes', 'UX review accepted', 'pytest -q passes']
-  - risk: ['KYC limitations', 'flaky tests', 'regulatory changes', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'general implementation risk', 'flaky tests']
-  - refs: [DR_0013](dr/analyses/DR_0013.yaml#L29-L44), [DR_0014](dr/analyses/DR_0014.yaml#L247-L266), [DR_0015](dr/analyses/DR_0015.yaml#L16-L22), [DR_0016](dr/analyses/DR_0016.yaml#L29-L40)
+- **Batch 1**: DR_0009, DR_0010
+  - changes: static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, pytest -q passes
+  - risk: flaky tests, general implementation risk
+  - refs: dr/analyses/DR_0009.yaml (L8969-L9005); dr/analyses/DR_0010.yaml (L9104-L9140)
+- **Batch 2**: DR_0011, DR_0012
+  - changes: bot/, docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, general implementation risk, regulatory changes
+  - refs: dr/analyses/DR_0011.yaml (L9141-L9187); dr/analyses/DR_0012.yaml (L9328-L9364)
+- **Batch 3**: DR_0013, DR_0014
+  - changes: bot/, core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0013.yaml (L9500-L9546); dr/analyses/DR_0014.yaml (L9598-L9635)
+- **Batch 4**: DR_0015, DR_0016
+  - changes: bot/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, pytest -q passes
+  - risk: flaky tests, general implementation risk
+  - refs: dr/analyses/DR_0015.yaml (L9822-L9858); dr/analyses/DR_0016.yaml (L9859-L9905)
 
 ## P2
-
-- **Batch 1 (DR_0017, DR_0018, DR_0019, DR_0020)** — parallel implementation
-  - changes: ['docs/compliance/', 'tests/', 'docs/compliance/', 'static/', 'templates/', 'tests/', 'core/', 'docs/compliance/', 'integrations/', 'static/', 'templates/', 'tests/']
-  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
-  - DoD: ['pytest -q passes', 'manual review by compliance officer', 'pytest -q passes', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'manual review by compliance officer', 'pytest -q passes']
-  - risk: ['general implementation risk', 'KYC limitations', 'flaky tests', 'regulatory changes', 'KYC limitations', 'flaky tests', 'regulatory changes', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime']
-  - refs: [DR_0017](dr/analyses/DR_0017.yaml#L19-L25), [DR_0018](dr/analyses/DR_0018.yaml#L23-L34), [DR_0019](dr/analyses/DR_0019.yaml#L29-L43), [DR_0020](dr/analyses/DR_0020.yaml#L67-L86)
-- **Batch 2 (DR_0021, DR_0022, DR_0023, DR_0024)** — parallel implementation
-  - changes: ['static/', 'templates/', 'tests/', 'core/', 'docs/compliance/', 'integrations/', 'tests/', 'core/', 'integrations/', 'static/', 'templates/', 'tests/']
-  - commands: ['ruff check .', 'ruff format .', 'black --check .', 'pytest -q']
-  - DoD: ['pytest -q passes', 'UX review accepted', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'manual review by compliance officer', 'pytest -q passes', 'HTTP 200 from integration endpoints', 'UX review accepted', 'pytest -q passes', 'vulnerability scan clean']
-  - risk: ['general implementation risk', 'flaky tests', 'API rate limits', 'KYC limitations', 'flaky tests', 'regulatory changes', 'third-party downtime', 'API rate limits', 'data breaches', 'flaky tests', 'misconfigured auth', 'third-party downtime']
-  - refs: [DR_0021](dr/analyses/DR_0021.yaml#L10-L16), [DR_0022](dr/analyses/DR_0022.yaml#L24-L34), [DR_0023](dr/analyses/DR_0023.yaml#L68-L84), [DR_0024](dr/analyses/DR_0024.yaml#L56-L74)
+- **Batch 1**: DR_0017, DR_0018
+  - changes: docs/compliance/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, general implementation risk, regulatory changes
+  - refs: dr/analyses/DR_0017.yaml (L10223-L10259); dr/analyses/DR_0018.yaml (L10358-L10394)
+- **Batch 2**: DR_0019, DR_0020
+  - changes: core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0019.yaml (L10395-L10441); dr/analyses/DR_0020.yaml (L10493-L10530)
+- **Batch 3**: DR_0021, DR_0022
+  - changes: static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, pytest -q passes
+  - risk: flaky tests, general implementation risk
+  - refs: dr/analyses/DR_0021.yaml (L10717-L10753); dr/analyses/DR_0022.yaml (L10754-L10800)
+- **Batch 4**: DR_0023, DR_0024
+  - changes: core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes, vulnerability scan clean
+  - risk: API rate limits, KYC limitations, data breaches, flaky tests, misconfigured auth, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0023.yaml (L10852-L11416); dr/analyses/DR_0024.yaml (L11810-L12147)

--- a/plan/tasks.json
+++ b/plan/tasks.json
@@ -1,18 +1,685 @@
 [
   {
-    "id": "P0-1",
-    "title": "Fix dependencies and add dev tools",
-    "changes": ["requirements.txt", "pyproject.toml"],
-    "commands": ["pip install -r requirements.txt", "ruff check .", "ruff format .", "black --check ."],
-    "dod": ["Dependencies install", "Lint and format pass"],
-    "risk": "low"
+    "id": "DR_0001",
+    "title": "review and implement recommendations",
+    "changes": [
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes"
+    ],
+    "dr_ids": [
+      "DR_0001"
+    ]
   },
   {
-    "id": "P0-2",
-    "title": "Enable pytest discovery",
-    "changes": ["pyproject.toml", "crypto_decline_index/tests/__init__.py"],
-    "commands": ["pytest -q"],
-    "dod": ["Tests run without ModuleNotFoundError"],
-    "risk": "low"
+    "id": "DR_0002",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "API rate limits",
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes",
+      "third-party downtime"
+    ],
+    "dr_ids": [
+      "DR_0002"
+    ]
+  },
+  {
+    "id": "DR_0003",
+    "title": "review and implement recommendations",
+    "changes": [
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes"
+    ],
+    "dr_ids": [
+      "DR_0003"
+    ]
+  },
+  {
+    "id": "DR_0004",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes"
+    ],
+    "dr_ids": [
+      "DR_0004"
+    ]
+  },
+  {
+    "id": "DR_0005",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "API rate limits",
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes",
+      "third-party downtime"
+    ],
+    "dr_ids": [
+      "DR_0005"
+    ]
+  },
+  {
+    "id": "DR_0006",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "API rate limits",
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes",
+      "third-party downtime"
+    ],
+    "dr_ids": [
+      "DR_0006"
+    ]
+  },
+  {
+    "id": "DR_0007",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes"
+    ],
+    "dr_ids": [
+      "DR_0007"
+    ]
+  },
+  {
+    "id": "DR_0008",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes",
+      "vulnerability scan clean"
+    ],
+    "risk": [
+      "API rate limits",
+      "KYC limitations",
+      "data breaches",
+      "flaky tests",
+      "misconfigured auth",
+      "regulatory changes",
+      "third-party downtime"
+    ],
+    "dr_ids": [
+      "DR_0008"
+    ]
+  },
+  {
+    "id": "DR_0009",
+    "title": "review and implement recommendations",
+    "changes": [
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": [
+      "flaky tests"
+    ],
+    "dr_ids": [
+      "DR_0009"
+    ]
+  },
+  {
+    "id": "DR_0010",
+    "title": "review and implement recommendations",
+    "changes": [
+      "static/",
+      "templates/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted"
+    ],
+    "risk": [
+      "general implementation risk"
+    ],
+    "dr_ids": [
+      "DR_0010"
+    ]
+  },
+  {
+    "id": "DR_0011",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes"
+    ],
+    "dr_ids": [
+      "DR_0011"
+    ]
+  },
+  {
+    "id": "DR_0012",
+    "title": "review and implement recommendations",
+    "changes": [],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": [
+      "general implementation risk"
+    ],
+    "dr_ids": [
+      "DR_0012"
+    ]
+  },
+  {
+    "id": "DR_0013",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes"
+    ],
+    "dr_ids": [
+      "DR_0013"
+    ]
+  },
+  {
+    "id": "DR_0014",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "API rate limits",
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes",
+      "third-party downtime"
+    ],
+    "dr_ids": [
+      "DR_0014"
+    ]
+  },
+  {
+    "id": "DR_0015",
+    "title": "review and implement recommendations",
+    "changes": [],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": [
+      "general implementation risk"
+    ],
+    "dr_ids": [
+      "DR_0015"
+    ]
+  },
+  {
+    "id": "DR_0016",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "flaky tests"
+    ],
+    "dr_ids": [
+      "DR_0016"
+    ]
+  },
+  {
+    "id": "DR_0017",
+    "title": "review and implement recommendations",
+    "changes": [],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": [
+      "general implementation risk"
+    ],
+    "dr_ids": [
+      "DR_0017"
+    ]
+  },
+  {
+    "id": "DR_0018",
+    "title": "review and implement recommendations",
+    "changes": [
+      "docs/compliance/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes"
+    ],
+    "dr_ids": [
+      "DR_0018"
+    ]
+  },
+  {
+    "id": "DR_0019",
+    "title": "review and implement recommendations",
+    "changes": [
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes"
+    ],
+    "dr_ids": [
+      "DR_0019"
+    ]
+  },
+  {
+    "id": "DR_0020",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "API rate limits",
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes",
+      "third-party downtime"
+    ],
+    "dr_ids": [
+      "DR_0020"
+    ]
+  },
+  {
+    "id": "DR_0021",
+    "title": "review and implement recommendations",
+    "changes": [],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": [
+      "general implementation risk"
+    ],
+    "dr_ids": [
+      "DR_0021"
+    ]
+  },
+  {
+    "id": "DR_0022",
+    "title": "review and implement recommendations",
+    "changes": [
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "flaky tests"
+    ],
+    "dr_ids": [
+      "DR_0022"
+    ]
+  },
+  {
+    "id": "DR_0023",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": [
+      "API rate limits",
+      "KYC limitations",
+      "flaky tests",
+      "regulatory changes",
+      "third-party downtime"
+    ],
+    "dr_ids": [
+      "DR_0023"
+    ]
+  },
+  {
+    "id": "DR_0024",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "pytest -q passes",
+      "vulnerability scan clean"
+    ],
+    "risk": [
+      "API rate limits",
+      "data breaches",
+      "flaky tests",
+      "misconfigured auth",
+      "third-party downtime"
+    ],
+    "dr_ids": [
+      "DR_0024"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary
- add conservative and aggressive implementation roadmaps derived from DR analyses
- publish machine-readable task list aligned with roadmap V1
- document how to choose between plans and run verification commands

## Testing
- `ruff check .`
- `ruff format .`
- `black --check .`
- `pytest -q` *(fails: AttributeError: module 'scrape_decline_index' has no attribute 'main')*


------
https://chatgpt.com/codex/tasks/task_e_68a11b93ba80832cbb37b237678cfa44