### PR TITLE
docs(plan): implementation roadmap (V1/V2) and task list

### DIFF
--- a/plan/README.md
+++ b/plan/README.md
@@ -1,0 +1,21 @@
+# Implementation Roadmap Plans
+
+This directory contains two roadmap variants generated from documented requirements in `dr/analyses`:
+
+- `roadmap_v1.md` – conservative sequencing in three phases (P0→P1→P2).
+- `roadmap_v2.md` – aggressive plan with parallel batches inside each phase.
+- `tasks.json` – machine-readable tasks derived from the aggressive plan (V2).
+
+## Choosing V1 vs V2
+- **V1** minimises risk by progressing sequentially. Use when capacity is limited or when strict gating is required before moving forward.
+- **V2** groups work into parallel batches to shorten calendar time. Chosen for `tasks.json` because tasks are independent and share identical verification gates.
+
+## Running Tasks Manually
+For any task:
+1. Ensure dependencies are installed: `python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt`.
+2. Execute verification gates:
+   - `ruff check .`
+   - `ruff format .`
+   - `black --check .`
+   - `pytest -q`
+3. Provide proof of work with command output and list of changed files.

--- a/plan/roadmap_v1.md
+++ b/plan/roadmap_v1.md
@@ -1,19 +1,152 @@
-# Roadmap v1
+# Roadmap V1 (Conservative)
 
 ## P0
-- **DR_P0_001 – Fix dependencies and add dev tools**
-  - changes: `requirements.txt`, `pyproject.toml`
-  - commands: `pip install -r requirements.txt`, `ruff check .`, `ruff format .`, `black --check .`
-  - DoD: dependencies install; lint/format pass
-  - risk: low
-- **DR_P0_002 – Enable pytest discovery**
-  - changes: `pyproject.toml`, `crypto_decline_index/tests/__init__.py`
-  - commands: `pytest -q`
-  - DoD: tests run without ModuleNotFoundError
-  - risk: low
+- **DR_0001** — review and implement recommendations
+  - changes: docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - ref: dr/analyses/DR_0001.yaml (L1587-L2396)
+- **DR_0002** — review and implement recommendations
+  - changes: core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - ref: dr/analyses/DR_0002.yaml (L2718-L2755)
+- **DR_0003** — review and implement recommendations
+  - changes: docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - ref: dr/analyses/DR_0003.yaml (L3150-L3195)
+- **DR_0004** — review and implement recommendations
+  - changes: bot/, docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - ref: dr/analyses/DR_0004.yaml (L3324-L3369)
+- **DR_0005** — review and implement recommendations
+  - changes: bot/, core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - ref: dr/analyses/DR_0005.yaml (L3411-L3454)
+- **DR_0006** — review and implement recommendations
+  - changes: bot/, core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - ref: dr/analyses/DR_0006.yaml (L4289-L7541)
+- **DR_0007** — review and implement recommendations
+  - changes: bot/, docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - ref: dr/analyses/DR_0007.yaml (L7765-L7811)
+- **DR_0008** — review and implement recommendations
+  - changes: bot/, core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes, vulnerability scan clean
+  - risk: API rate limits, KYC limitations, data breaches, flaky tests, misconfigured auth, regulatory changes, third-party downtime
+  - ref: dr/analyses/DR_0008.yaml (L7863-L8917)
 
 ## P1
-_No DR analyses found._
+- **DR_0009** — review and implement recommendations
+  - changes: tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: pytest -q passes
+  - risk: flaky tests
+  - ref: dr/analyses/DR_0009.yaml (L8969-L9005)
+- **DR_0010** — review and implement recommendations
+  - changes: static/, templates/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted
+  - risk: general implementation risk
+  - ref: dr/analyses/DR_0010.yaml (L9104-L9140)
+- **DR_0011** — review and implement recommendations
+  - changes: bot/, docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - ref: dr/analyses/DR_0011.yaml (L9141-L9187)
+- **DR_0012** — review and implement recommendations
+  - changes: 
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: pytest -q passes
+  - risk: general implementation risk
+  - ref: dr/analyses/DR_0012.yaml (L9328-L9364)
+- **DR_0013** — review and implement recommendations
+  - changes: bot/, docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - ref: dr/analyses/DR_0013.yaml (L9500-L9546)
+- **DR_0014** — review and implement recommendations
+  - changes: core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - ref: dr/analyses/DR_0014.yaml (L9598-L9635)
+- **DR_0015** — review and implement recommendations
+  - changes: 
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: pytest -q passes
+  - risk: general implementation risk
+  - ref: dr/analyses/DR_0015.yaml (L9822-L9858)
+- **DR_0016** — review and implement recommendations
+  - changes: bot/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, pytest -q passes
+  - risk: flaky tests
+  - ref: dr/analyses/DR_0016.yaml (L9859-L9905)
 
 ## P2
-_No DR analyses found._
+- **DR_0017** — review and implement recommendations
+  - changes: 
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: pytest -q passes
+  - risk: general implementation risk
+  - ref: dr/analyses/DR_0017.yaml (L10223-L10259)
+- **DR_0018** — review and implement recommendations
+  - changes: docs/compliance/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - ref: dr/analyses/DR_0018.yaml (L10358-L10394)
+- **DR_0019** — review and implement recommendations
+  - changes: docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - ref: dr/analyses/DR_0019.yaml (L10395-L10441)
+- **DR_0020** — review and implement recommendations
+  - changes: core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - ref: dr/analyses/DR_0020.yaml (L10493-L10530)
+- **DR_0021** — review and implement recommendations
+  - changes: 
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: pytest -q passes
+  - risk: general implementation risk
+  - ref: dr/analyses/DR_0021.yaml (L10717-L10753)
+- **DR_0022** — review and implement recommendations
+  - changes: static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, pytest -q passes
+  - risk: flaky tests
+  - ref: dr/analyses/DR_0022.yaml (L10754-L10800)
+- **DR_0023** — review and implement recommendations
+  - changes: core/, docs/compliance/, integrations/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - ref: dr/analyses/DR_0023.yaml (L10852-L11416)
+- **DR_0024** — review and implement recommendations
+  - changes: core/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, pytest -q passes, vulnerability scan clean
+  - risk: API rate limits, data breaches, flaky tests, misconfigured auth, third-party downtime
+  - ref: dr/analyses/DR_0024.yaml (L11810-L12147)
+

--- a/plan/roadmap_v2.md
+++ b/plan/roadmap_v2.md
@@ -1,0 +1,80 @@
+# Roadmap V2 (Aggressive)
+
+## P0
+- **Batch 1**: DR_0001, DR_0002
+  - changes: core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0001.yaml (L1587-L2396); dr/analyses/DR_0002.yaml (L2718-L2755)
+- **Batch 2**: DR_0003, DR_0004
+  - changes: bot/, docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, regulatory changes
+  - refs: dr/analyses/DR_0003.yaml (L3150-L3195); dr/analyses/DR_0004.yaml (L3324-L3369)
+- **Batch 3**: DR_0005, DR_0006
+  - changes: bot/, core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0005.yaml (L3411-L3454); dr/analyses/DR_0006.yaml (L4289-L7541)
+- **Batch 4**: DR_0007, DR_0008
+  - changes: bot/, core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes, vulnerability scan clean
+  - risk: API rate limits, KYC limitations, data breaches, flaky tests, misconfigured auth, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0007.yaml (L7765-L7811); dr/analyses/DR_0008.yaml (L7863-L8917)
+
+## P1
+- **Batch 1**: DR_0009, DR_0010
+  - changes: static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, pytest -q passes
+  - risk: flaky tests, general implementation risk
+  - refs: dr/analyses/DR_0009.yaml (L8969-L9005); dr/analyses/DR_0010.yaml (L9104-L9140)
+- **Batch 2**: DR_0011, DR_0012
+  - changes: bot/, docs/compliance/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, general implementation risk, regulatory changes
+  - refs: dr/analyses/DR_0011.yaml (L9141-L9187); dr/analyses/DR_0012.yaml (L9328-L9364)
+- **Batch 3**: DR_0013, DR_0014
+  - changes: bot/, core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0013.yaml (L9500-L9546); dr/analyses/DR_0014.yaml (L9598-L9635)
+- **Batch 4**: DR_0015, DR_0016
+  - changes: bot/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, pytest -q passes
+  - risk: flaky tests, general implementation risk
+  - refs: dr/analyses/DR_0015.yaml (L9822-L9858); dr/analyses/DR_0016.yaml (L9859-L9905)
+
+## P2
+- **Batch 1**: DR_0017, DR_0018
+  - changes: docs/compliance/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: manual review by compliance officer, pytest -q passes
+  - risk: KYC limitations, flaky tests, general implementation risk, regulatory changes
+  - refs: dr/analyses/DR_0017.yaml (L10223-L10259); dr/analyses/DR_0018.yaml (L10358-L10394)
+- **Batch 2**: DR_0019, DR_0020
+  - changes: core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes
+  - risk: API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0019.yaml (L10395-L10441); dr/analyses/DR_0020.yaml (L10493-L10530)
+- **Batch 3**: DR_0021, DR_0022
+  - changes: static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: UX review accepted, pytest -q passes
+  - risk: flaky tests, general implementation risk
+  - refs: dr/analyses/DR_0021.yaml (L10717-L10753); dr/analyses/DR_0022.yaml (L10754-L10800)
+- **Batch 4**: DR_0023, DR_0024
+  - changes: core/, docs/compliance/, integrations/, static/, templates/, tests/
+  - commands: ruff check ., ruff format ., black --check ., pytest -q
+  - DoD: HTTP 200 from integration endpoints, UX review accepted, manual review by compliance officer, pytest -q passes, vulnerability scan clean
+  - risk: API rate limits, KYC limitations, data breaches, flaky tests, misconfigured auth, regulatory changes, third-party downtime
+  - refs: dr/analyses/DR_0023.yaml (L10852-L11416); dr/analyses/DR_0024.yaml (L11810-L12147)
+

--- a/plan/tasks.json
+++ b/plan/tasks.json
@@ -1,18 +1,707 @@
 [
   {
-    "id": "P0-1",
-    "title": "Fix dependencies and add dev tools",
-    "changes": ["requirements.txt", "pyproject.toml"],
-    "commands": ["pip install -r requirements.txt", "ruff check .", "ruff format .", "black --check ."],
-    "dod": ["Dependencies install", "Lint and format pass"],
-    "risk": "low"
+    "id": "DR_0001-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "KYC limitations, flaky tests, regulatory changes",
+    "dr_ids": [
+      "DR_0001"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0001.yaml",
+      "sha256": "f177e769672cd2fc5fc3c9cbff41275e97f79825cef0b45bca491f738dd8fb2f",
+      "span": "L1587-L2396"
+    }
   },
   {
-    "id": "P0-2",
-    "title": "Enable pytest discovery",
-    "changes": ["pyproject.toml", "crypto_decline_index/tests/__init__.py"],
-    "commands": ["pytest -q"],
-    "dod": ["Tests run without ModuleNotFoundError"],
-    "risk": "low"
+    "id": "DR_0002-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime",
+    "dr_ids": [
+      "DR_0002"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0002.yaml",
+      "sha256": "4b2e3a428b89a47c92fa28b8dbd7a2a78239a96215dbf888329925ec51b73f31",
+      "span": "L2718-L2755"
+    }
+  },
+  {
+    "id": "DR_0003-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "KYC limitations, flaky tests, regulatory changes",
+    "dr_ids": [
+      "DR_0003"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0003.yaml",
+      "sha256": "d8d1419e6387186bcd166f1fd73eb1393448a8e574f49a795ed0b601dbfbaf83",
+      "span": "L3150-L3195"
+    }
+  },
+  {
+    "id": "DR_0004-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "KYC limitations, flaky tests, regulatory changes",
+    "dr_ids": [
+      "DR_0004"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0004.yaml",
+      "sha256": "2d89ba8e0334cb78464e26fb21c6b552c2905386a1c00974dc622d0af2aefe39",
+      "span": "L3324-L3369"
+    }
+  },
+  {
+    "id": "DR_0005-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime",
+    "dr_ids": [
+      "DR_0005"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0005.yaml",
+      "sha256": "698a5d1cc88cb2fd8c3e3ba0cd9283ffb75e897cc98472279b71fa08f27a7e88",
+      "span": "L3411-L3454"
+    }
+  },
+  {
+    "id": "DR_0006-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime",
+    "dr_ids": [
+      "DR_0006"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0006.yaml",
+      "sha256": "ec2fcd951c33d19c638ebe8f073f8ddf7b9d8a253688dc54e8b0129278370c4e",
+      "span": "L4289-L7541"
+    }
+  },
+  {
+    "id": "DR_0007-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "KYC limitations, flaky tests, regulatory changes",
+    "dr_ids": [
+      "DR_0007"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0007.yaml",
+      "sha256": "d6f4eeaacf8728e8dc99bf27b096d8f1d610b261727a33dfeb51f106fb4a1681",
+      "span": "L7765-L7811"
+    }
+  },
+  {
+    "id": "DR_0008-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes",
+      "vulnerability scan clean"
+    ],
+    "risk": "API rate limits, KYC limitations, data breaches, flaky tests, misconfigured auth, regulatory changes, third-party downtime",
+    "dr_ids": [
+      "DR_0008"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0008.yaml",
+      "sha256": "66eda2cbf034c43e3a0230037a28327c02b5b3d43ed5bd67ca9a398d17db4f38",
+      "span": "L7863-L8917"
+    }
+  },
+  {
+    "id": "DR_0009-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": "flaky tests",
+    "dr_ids": [
+      "DR_0009"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0009.yaml",
+      "sha256": "2bd880fa149f3f221d16073f9e7dd37e80090ca52c2e389371f3265e108ff42f",
+      "span": "L8969-L9005"
+    }
+  },
+  {
+    "id": "DR_0010-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "static/",
+      "templates/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted"
+    ],
+    "risk": "general implementation risk",
+    "dr_ids": [
+      "DR_0010"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0010.yaml",
+      "sha256": "d397fe0a17b08c77e41bf15c787e1f543797c84190fbdb0f4ed50e312bdb5452",
+      "span": "L9104-L9140"
+    }
+  },
+  {
+    "id": "DR_0011-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "KYC limitations, flaky tests, regulatory changes",
+    "dr_ids": [
+      "DR_0011"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0011.yaml",
+      "sha256": "97782f26723e55cd1e4bba1ea21bebb585e9803f6ecf56cdfdf6b9eacbca3b50",
+      "span": "L9141-L9187"
+    }
+  },
+  {
+    "id": "DR_0012-01",
+    "title": "review and implement recommendations",
+    "changes": [],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": "general implementation risk",
+    "dr_ids": [
+      "DR_0012"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0012.yaml",
+      "sha256": "2101f659b4391404086a03563f6915b3377caa858cdf29a4431bfdc51e959246",
+      "span": "L9328-L9364"
+    }
+  },
+  {
+    "id": "DR_0013-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "KYC limitations, flaky tests, regulatory changes",
+    "dr_ids": [
+      "DR_0013"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0013.yaml",
+      "sha256": "280a66e78eeeefca0a6220bf61b0d2511fe115294980a253b85becbbc9cbab33",
+      "span": "L9500-L9546"
+    }
+  },
+  {
+    "id": "DR_0014-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime",
+    "dr_ids": [
+      "DR_0014"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0014.yaml",
+      "sha256": "f2487c753a615b89c3267b544d7986faff27255e37bb78e6b58e6a7087082074",
+      "span": "L9598-L9635"
+    }
+  },
+  {
+    "id": "DR_0015-01",
+    "title": "review and implement recommendations",
+    "changes": [],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": "general implementation risk",
+    "dr_ids": [
+      "DR_0015"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0015.yaml",
+      "sha256": "8bfe23514265dcfe7fdd834ebd8e48851ff973704d60999007b5f1a45c7f83aa",
+      "span": "L9822-L9858"
+    }
+  },
+  {
+    "id": "DR_0016-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "bot/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "pytest -q passes"
+    ],
+    "risk": "flaky tests",
+    "dr_ids": [
+      "DR_0016"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0016.yaml",
+      "sha256": "cbe21a048366d6db5e616f3d6d6ccab6d9e9dcfd81ce819ebf2f6d44934b550e",
+      "span": "L9859-L9905"
+    }
+  },
+  {
+    "id": "DR_0017-01",
+    "title": "review and implement recommendations",
+    "changes": [],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": "general implementation risk",
+    "dr_ids": [
+      "DR_0017"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0017.yaml",
+      "sha256": "08921ded60d522880781b59bbcb0fb8715f66a12f4b269a03f75ece1836ee888",
+      "span": "L10223-L10259"
+    }
+  },
+  {
+    "id": "DR_0018-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "docs/compliance/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "KYC limitations, flaky tests, regulatory changes",
+    "dr_ids": [
+      "DR_0018"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0018.yaml",
+      "sha256": "81aaafcd6cc2bfb444e392bf0818e721b9d69d91cbcbb03cf94ebd86f9745864",
+      "span": "L10358-L10394"
+    }
+  },
+  {
+    "id": "DR_0019-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "docs/compliance/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "KYC limitations, flaky tests, regulatory changes",
+    "dr_ids": [
+      "DR_0019"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0019.yaml",
+      "sha256": "225eebe8fb5080f338711e051ec452e62e35ce3d1540d89c15d0aa265a594c92",
+      "span": "L10395-L10441"
+    }
+  },
+  {
+    "id": "DR_0020-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime",
+    "dr_ids": [
+      "DR_0020"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0020.yaml",
+      "sha256": "0d08b0ff3ba724ae3cb1aba322a794f52b2470156a58b3ce33b922c1889cf0e6",
+      "span": "L10493-L10530"
+    }
+  },
+  {
+    "id": "DR_0021-01",
+    "title": "review and implement recommendations",
+    "changes": [],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "pytest -q passes"
+    ],
+    "risk": "general implementation risk",
+    "dr_ids": [
+      "DR_0021"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0021.yaml",
+      "sha256": "0922b8656fff77a3593181faf508a04836446ced38fa1f341beb8eda28813335",
+      "span": "L10717-L10753"
+    }
+  },
+  {
+    "id": "DR_0022-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "UX review accepted",
+      "pytest -q passes"
+    ],
+    "risk": "flaky tests",
+    "dr_ids": [
+      "DR_0022"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0022.yaml",
+      "sha256": "419b575f3d48dc30c86f6c952e8382a56bf140ddddcb41aacab68577d708aa15",
+      "span": "L10754-L10800"
+    }
+  },
+  {
+    "id": "DR_0023-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "docs/compliance/",
+      "integrations/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "manual review by compliance officer",
+      "pytest -q passes"
+    ],
+    "risk": "API rate limits, KYC limitations, flaky tests, regulatory changes, third-party downtime",
+    "dr_ids": [
+      "DR_0023"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0023.yaml",
+      "sha256": "7986ba7ced1ea30a1a99fad01d8f83310fec1dc03147503d523f9b273457b521",
+      "span": "L10852-L11416"
+    }
+  },
+  {
+    "id": "DR_0024-01",
+    "title": "review and implement recommendations",
+    "changes": [
+      "core/",
+      "integrations/",
+      "static/",
+      "templates/",
+      "tests/"
+    ],
+    "commands": [
+      "ruff check .",
+      "ruff format .",
+      "black --check .",
+      "pytest -q"
+    ],
+    "dod": [
+      "HTTP 200 from integration endpoints",
+      "UX review accepted",
+      "pytest -q passes",
+      "vulnerability scan clean"
+    ],
+    "risk": "API rate limits, data breaches, flaky tests, misconfigured auth, third-party downtime",
+    "dr_ids": [
+      "DR_0024"
+    ],
+    "ref": {
+      "file": "dr/analyses/DR_0024.yaml",
+      "sha256": "4fc987112793e0ec4ca2d0c8ba7885bffbbabdbd6c2827c324f691e1f837fe52",
+      "span": "L11810-L12147"
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- add conservative and aggressive implementation roadmaps derived from DR analyses
- provide machine-readable tasks list and plan README with execution guidance

## Testing
- `ruff check .`
- `ruff format .`
- `black --check .`
- `pytest -q` *(fails: AttributeError: module 'scrape_decline_index' has no attribute 'main')*


------
https://chatgpt.com/codex/tasks/task_e_68a11b93ba80832cbb37b237678cfa44