### PR TITLE
chore: sync roadmap V1 tasks and add meta controls

### DIFF
--- a/docs/IMPLEMENTATION_LOG.md
+++ b/docs/IMPLEMENTATION_LOG.md
@@ -1,0 +1,3 @@
+# Implementation Log
+
+2025-08-17 05:51 (Europe/Kyiv) — chore(plan): sync roadmap with tasks; commit 4221bc39ec6aca0a379b7c48f6f05fc9a12deaf8; files: plan/tasks.json, plan/checklist_V1.md, docs/IMPLEMENTATION_LOG.md, plan/tasks_audit.md; reason: initial meta-control setup; links: N/A

--- a/plan/checklist_V1.md
+++ b/plan/checklist_V1.md
@@ -1,0 +1,30 @@
+# Checklist V1
+
+## Remaining
+- [ ] DR_0001 — review and implement recommendations
+- [ ] DR_0002 — review and implement recommendations
+- [ ] DR_0003 — review and implement recommendations
+- [ ] DR_0004 — review and implement recommendations
+- [ ] DR_0005 — review and implement recommendations
+- [ ] DR_0006 — review and implement recommendations
+- [ ] DR_0007 — review and implement recommendations
+- [ ] DR_0008 — review and implement recommendations
+- [ ] DR_0009 — review and implement recommendations
+- [ ] DR_0010 — review and implement recommendations
+- [ ] DR_0011 — review and implement recommendations
+- [ ] DR_0012 — review and implement recommendations
+- [ ] DR_0013 — review and implement recommendations
+- [ ] DR_0014 — review and implement recommendations
+- [ ] DR_0015 — review and implement recommendations
+- [ ] DR_0016 — review and implement recommendations
+- [ ] DR_0017 — review and implement recommendations
+- [ ] DR_0018 — review and implement recommendations
+- [ ] DR_0019 — review and implement recommendations
+- [ ] DR_0020 — review and implement recommendations
+- [ ] DR_0021 — review and implement recommendations
+- [ ] DR_0022 — review and implement recommendations
+- [ ] DR_0023 — review and implement recommendations
+- [ ] DR_0024 — review and implement recommendations
+
+## Done
+

--- a/plan/tasks.json
+++ b/plan/tasks.json
@@ -26,7 +26,10 @@
     ],
     "dr_ids": [
       "DR_0001"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [],
+    "roadmap_ref": "plan/roadmap_v1.md#L5-L10"
   },
   {
     "id": "DR_0002",
@@ -60,7 +63,12 @@
     ],
     "dr_ids": [
       "DR_0002"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0001"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L11-L16"
   },
   {
     "id": "DR_0003",
@@ -89,7 +97,12 @@
     ],
     "dr_ids": [
       "DR_0003"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0002"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L17-L22"
   },
   {
     "id": "DR_0004",
@@ -119,7 +132,12 @@
     ],
     "dr_ids": [
       "DR_0004"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0003"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L23-L28"
   },
   {
     "id": "DR_0005",
@@ -154,7 +172,12 @@
     ],
     "dr_ids": [
       "DR_0005"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0004"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L29-L34"
   },
   {
     "id": "DR_0006",
@@ -189,7 +212,12 @@
     ],
     "dr_ids": [
       "DR_0006"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0005"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L35-L40"
   },
   {
     "id": "DR_0007",
@@ -219,7 +247,12 @@
     ],
     "dr_ids": [
       "DR_0007"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0006"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L41-L46"
   },
   {
     "id": "DR_0008",
@@ -257,7 +290,12 @@
     ],
     "dr_ids": [
       "DR_0008"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0007"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L47-L52"
   },
   {
     "id": "DR_0009",
@@ -279,7 +317,12 @@
     ],
     "dr_ids": [
       "DR_0009"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0008"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L56-L61"
   },
   {
     "id": "DR_0010",
@@ -302,7 +345,12 @@
     ],
     "dr_ids": [
       "DR_0010"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0009"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L62-L67"
   },
   {
     "id": "DR_0011",
@@ -332,7 +380,12 @@
     ],
     "dr_ids": [
       "DR_0011"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0010"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L68-L73"
   },
   {
     "id": "DR_0012",
@@ -352,7 +405,13 @@
     ],
     "dr_ids": [
       "DR_0012"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0011"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L74-L79",
+    "needs_clarification": true
   },
   {
     "id": "DR_0013",
@@ -382,7 +441,12 @@
     ],
     "dr_ids": [
       "DR_0013"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0012"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L80-L85"
   },
   {
     "id": "DR_0014",
@@ -416,7 +480,12 @@
     ],
     "dr_ids": [
       "DR_0014"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0013"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L86-L91"
   },
   {
     "id": "DR_0015",
@@ -436,7 +505,13 @@
     ],
     "dr_ids": [
       "DR_0015"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0014"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L92-L97",
+    "needs_clarification": true
   },
   {
     "id": "DR_0016",
@@ -462,7 +537,12 @@
     ],
     "dr_ids": [
       "DR_0016"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0015"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L98-L103"
   },
   {
     "id": "DR_0017",
@@ -482,7 +562,13 @@
     ],
     "dr_ids": [
       "DR_0017"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0016"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L107-L112",
+    "needs_clarification": true
   },
   {
     "id": "DR_0018",
@@ -508,7 +594,12 @@
     ],
     "dr_ids": [
       "DR_0018"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0017"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L113-L118"
   },
   {
     "id": "DR_0019",
@@ -537,7 +628,12 @@
     ],
     "dr_ids": [
       "DR_0019"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0018"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L119-L124"
   },
   {
     "id": "DR_0020",
@@ -571,7 +667,12 @@
     ],
     "dr_ids": [
       "DR_0020"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0019"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L125-L130"
   },
   {
     "id": "DR_0021",
@@ -591,7 +692,13 @@
     ],
     "dr_ids": [
       "DR_0021"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0020"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L131-L136",
+    "needs_clarification": true
   },
   {
     "id": "DR_0022",
@@ -616,7 +723,12 @@
     ],
     "dr_ids": [
       "DR_0022"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0021"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L137-L142"
   },
   {
     "id": "DR_0023",
@@ -647,7 +759,12 @@
     ],
     "dr_ids": [
       "DR_0023"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0022"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L143-L148"
   },
   {
     "id": "DR_0024",
@@ -680,6 +797,11 @@
     ],
     "dr_ids": [
       "DR_0024"
-    ]
+    ],
+    "status": "pending",
+    "depends_on": [
+      "DR_0023"
+    ],
+    "roadmap_ref": "plan/roadmap_v1.md#L149-L154"
   }
 ]

--- a/plan/tasks_audit.md
+++ b/plan/tasks_audit.md
@@ -1,0 +1,8 @@
+# Tasks Audit V1
+
+| Issue | Resolution |
+|-------|-----------|
+| No statuses or dependencies in tasks.json | Added `status` and sequential `depends_on` fields for each task. |
+| Missing roadmap references | Added `roadmap_ref` pointing to relevant sections in `plan/roadmap_v1.md`. |
+| Ambiguous tasks with unspecified changes | Marked with `needs_clarification: true` for DR_0012, DR_0015, DR_0017, DR_0021. |
+| Checklist not previously present | Generated `plan/checklist_V1.md` with remaining tasks. |


### PR DESCRIPTION
## Summary
- align `plan/tasks.json` with roadmap V1 (statuses, dependencies, refs)
- add checklist and implementation log for V1 tracking
- document audit of task alignment

## Testing
- `ruff check .`
- `black --check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a142e89a80832c80a6d66c9be5d577